### PR TITLE
Make DiscordIpc trait object safe

### DIFF
--- a/src/discord_ipc.rs
+++ b/src/discord_ipc.rs
@@ -98,9 +98,7 @@ pub trait DiscordIpc {
     /// an opcode as its parameters.
     /// 
     /// # Errors
-    /// Returns an `Err` variant if:
-    /// * The data could not be serialized as JSON
-    /// * Writing to the socket failed
+    /// Returns an `Err` variant if writing to the socket failed
     /// 
     /// # Examples
     /// ```


### PR DESCRIPTION
Decided to make this in order to have an ability to create `Box<dyn DiscordIpc>`, `Arc<dyn DiscordIpc>` etc. To achieve this I have removed generic type parameters from the functions of `DiscordIpc`.