### PR TITLE
Use u64 for client_id instead of String

### DIFF
--- a/src/discord_ipc.rs
+++ b/src/discord_ipc.rs
@@ -63,7 +63,7 @@ pub trait DiscordIpc {
     }
 
     #[doc(hidden)]
-    fn get_client_id(&self) -> &String;
+    fn get_client_id(&self) -> String;
 
     #[doc(hidden)]
     fn connect_ipc(&mut self) -> Result<()>;
@@ -179,9 +179,9 @@ pub trait DiscordIpc {
     }
 
     /// Works the same as as [`set_activity`] but clears activity instead.
-    /// 
+    ///
     /// [`set_activity`]: #method.set_activity
-    /// 
+    ///
     /// # Errors
     /// Returns an `Err` variant if sending the payload failed.
     fn clear_activity(&mut self) -> Result<()> {
@@ -193,7 +193,7 @@ pub trait DiscordIpc {
             },
             "nonce": Uuid::new_v4().to_string()
         });
-        
+
         self.send(data, 1)?;
 
         Ok(())

--- a/src/ipc_unix.rs
+++ b/src/ipc_unix.rs
@@ -1,11 +1,11 @@
 use crate::discord_ipc::DiscordIpc;
 use serde_json::json;
-use std::os::unix::net::UnixStream;
 use std::{
     env::var,
     error::Error,
     io::{Read, Write},
     net::Shutdown,
+    os::unix::net::UnixStream,
     path::PathBuf,
 };
 
@@ -27,7 +27,7 @@ type Result<T> = std::result::Result<T, Box<dyn Error>>;
 /// underlying [`DiscordIpc`](trait@DiscordIpc) trait.
 pub struct DiscordIpcClient {
     /// Client ID of the IPC client.
-    pub client_id: String,
+    pub client_id: u64,
     connected: bool,
     socket: Option<UnixStream>,
 }
@@ -39,9 +39,9 @@ impl DiscordIpcClient {
     /// ```
     /// let ipc_client = DiscordIpcClient::new("<some client id>")?;
     /// ```
-    pub fn new(client_id: &str) -> Result<Self> {
+    pub fn new(client_id: u64) -> Result<Self> {
         let client = Self {
-            client_id: client_id.to_string(),
+            client_id: client_id,
             connected: false,
             socket: None,
         };
@@ -126,7 +126,7 @@ impl DiscordIpc for DiscordIpcClient {
         Ok(())
     }
 
-    fn get_client_id(&self) -> &String {
-        &self.client_id
+    fn get_client_id(&self) -> String {
+        self.client_id.to_string()
     }
 }

--- a/src/ipc_windows.rs
+++ b/src/ipc_windows.rs
@@ -16,7 +16,7 @@ type Result<T> = std::result::Result<T, Box<dyn Error>>;
 /// underlying [`DiscordIpc`](trait@DiscordIpc) trait.
 pub struct DiscordIpcClient {
     /// Client ID of the IPC client.
-    pub client_id: String,
+    pub client_id: u64,
     connected: bool,
     socket: Option<File>,
 }
@@ -28,9 +28,9 @@ impl DiscordIpcClient {
     /// ```
     /// let ipc_client = DiscordIpcClient::new("<some client id>")?;
     /// ```
-    pub fn new(client_id: &str) -> Result<Self> {
+    pub fn new(client_id: u64) -> Result<Self> {
         let client = Self {
-            client_id: client_id.to_string(),
+            client_id: client_id,
             connected: false,
             socket: None,
         };
@@ -91,7 +91,7 @@ impl DiscordIpc for DiscordIpcClient {
         Ok(())
     }
 
-    fn get_client_id(&self) -> &String {
-        &self.client_id
+    fn get_client_id(&self) -> String {
+        self.client_id.to_string()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,6 @@ pub use ipc::DiscordIpcClient;
 /// ```
 /// let ipc_client = discord_ipc_client::new_client("<some client id>")?;
 /// ```
-pub fn new_client(client_id: &str) -> Result<impl DiscordIpc, Box<dyn std::error::Error>> {
+pub fn new_client(client_id: u64) -> Result<impl DiscordIpc, Box<dyn std::error::Error>> {
     ipc::DiscordIpcClient::new(client_id)
 }

--- a/tests/models_test.rs
+++ b/tests/models_test.rs
@@ -3,7 +3,7 @@ use std::error::Error;
 
 #[test]
 fn test_models() -> Result<(), Box<dyn Error>> {
-    let mut client = DiscordIpcClient::new("771124766517755954")?;
+    let mut client = DiscordIpcClient::new(771124766517755954)?;
     client.connect()?;
 
     let activity = activity::Activity::new()

--- a/tests/reconnect_test.rs
+++ b/tests/reconnect_test.rs
@@ -3,7 +3,7 @@ use std::error::Error;
 
 #[test]
 fn test_reconnect() -> Result<(), Box<dyn Error>> {
-    let mut client = DiscordIpcClient::new("771124766517755954")?;
+    let mut client = DiscordIpcClient::new(771124766517755954)?;
     loop {
         if client.connect().is_ok() {
             break;

--- a/tests/update_test.rs
+++ b/tests/update_test.rs
@@ -3,7 +3,7 @@ use std::error::Error;
 
 #[test]
 fn test_updating() -> Result<(), Box<dyn Error>> {
-    let mut client = DiscordIpcClient::new("771124766517755954")?;
+    let mut client = DiscordIpcClient::new(771124766517755954)?;
     client.connect()?;
 
     client.set_activity(


### PR DESCRIPTION
I just found it weird that client ids were always numbers but inputted as a str so I changed that. I haven't tested it on Windows but on Unix it seems to work