### PR TITLE
Add ActivityType to activity struct

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,6 @@ documentation = "https://docs.rs/discord-rich-presence"
 [dependencies]
 serde_json = "1.0"
 serde = "1.0"
+serde_repr = "0.1"
 serde_derive = "1.0"
 uuid = { version = "0.8", features = ["v4"] }

--- a/src/activity.rs
+++ b/src/activity.rs
@@ -1,6 +1,7 @@
 //! Provides an interface for building activities to send
 //! to Discord via [`DiscordIpc::set_activity`](crate::DiscordIpc::set_activity).
 use serde_derive::Serialize;
+use serde_repr::Serialize_repr;
 
 /// A struct representing a Discord rich presence activity
 ///
@@ -28,6 +29,9 @@ pub struct Activity<'a> {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     buttons: Option<Vec<Button<'a>>>,
+
+    #[serde(skip_serializing_if = "Option::is_none", rename = "type")]
+    activity_type: Option<ActivityType>,
 }
 
 /// A struct representing an `Activity`'s timestamps
@@ -103,6 +107,20 @@ pub struct Button<'a> {
     url: &'a str,
 }
 
+/// A struct to set the Activity Type of the `Activity`
+#[derive(Serialize_repr, Clone)]
+#[repr(u8)]
+pub enum ActivityType {
+    /// Activity type "Playing X"
+    Playing = 0,
+    /// Activity type "Listening to X"
+    Listening = 2,
+    /// Activity type "Watching X"
+    Watching = 3,
+    /// Activity type "Competing in X"
+    Competing = 5,
+}
+
 impl<'a> Activity<'a> {
     /// Creates a new `Activity`
     pub fn new() -> Self {
@@ -114,6 +132,7 @@ impl<'a> Activity<'a> {
             party: None,
             secrets: None,
             timestamps: None,
+            activity_type: None,
         }
     }
 
@@ -164,6 +183,12 @@ impl<'a> Activity<'a> {
         }
 
         self.buttons = Some(buttons);
+        self
+    }
+
+    /// Add an `ActivityType` to this activity
+    pub fn activity_type(mut self, activity_type: ActivityType) -> Self {
+        self.activity_type = Some(activity_type);
         self
     }
 }


### PR DESCRIPTION
Discord now allows setting the type of activity, the ones they expose are Playing (0), Listening (2), Watching (3) and Competing (5).

This PR adds in a new enum `ActivityType` and uses serde_repr to serialize to integers for sending to discord.