### PR TITLE
Add authorize, authenticate, and voice settings

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,16 @@
+name: Cargo Check
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  check:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,4 @@ serde_derive = "1.0"
 uuid = { version = "0.8", features = ["v4"] }
 log = "0.4.26"
 thiserror = "2.0.12"
+serde_with = "3.12.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "discord-rich-presence"
-version = "0.2.5"
+version = "1.1.0"
 authors = ["Violet <110789901+vionya@users.noreply.github.com>"]
 edition = "2018"
 description = "A simple, cross-platform crate for interfacing with Discord's IPC"

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 vionya
+Copyright (c) 2025 vionya
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Discord Rich Presence
 [![crates.io](https://img.shields.io/crates/v/discord-rich-presence.svg)](https://crates.io/crates/discord-rich-presence)
-[![Docs](https://docs.rs/discord-rich-presence/badge.svg?version=0.2.5)](https://docs.rs/discord-rich-presence)
+[![Docs](https://docs.rs/discord-rich-presence/badge.svg?version=1.1.0)](https://docs.rs/discord-rich-presence)
 
 
 A simple, cross-platform crate to connect and send data to Discord's IPC. Special attention is given to sending rich presence data.
@@ -10,7 +10,7 @@ A simple, cross-platform crate to connect and send data to Discord's IPC. Specia
 use discord_rich_presence::{activity, DiscordIpc, DiscordIpcClient};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut client = DiscordIpcClient::new("<some application ID>")?;
+    let mut client = DiscordIpcClient::new("<some application ID>");
 
     client.connect()?;
     client.set_activity(activity::Activity::new()

--- a/examples/presence.rs
+++ b/examples/presence.rs
@@ -13,6 +13,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         _ => (),
     }
 
-    client.close()?;
+    println!("Clearing activity...");
+    client.clear_activity()?;
+
+    println!("Activity cleared! Going to exit...");
+    match client.close() {
+        Ok(()) => (),
+        Err(err) => println!("Error closing IPC connection: {}", err),
+    }
+
     Ok(())
 }

--- a/src/discord_ipc.rs
+++ b/src/discord_ipc.rs
@@ -2,6 +2,7 @@ use crate::{
     activity::Activity,
     error::Error,
     pack_unpack::{pack, unpack},
+    voice_settings::VoiceSettings,
 };
 use serde_json::{json, Map, Value};
 use uuid::Uuid;
@@ -254,6 +255,26 @@ pub trait DiscordIpc {
         } else {
             Ok(())
         }
+    }
+
+    /// Gets the current voice settings of the client.
+    ///
+    /// See [GET_VOICE_SETTINGS](https://discord.com/developers/docs/topics/rpc#getvoicesettings).
+    fn get_voice_settings(&mut self) -> Result<VoiceSettings> {
+        let args = json!({});
+        let d = self.command("GET_VOICE_SETTINGS", args)?;
+        Ok(serde_json::from_value(d).map_err(|_| Error::JsonParseResponse)?)
+    }
+
+    /// Sets the current voice settings of the client. Returns the current complete state of voice settings.
+    ///
+    /// Only one RPC client may control these settings at a time. No two clients may have the "rpc.voice.write" scope at once.
+    ///
+    /// See [SET_VOICE_SETTINGS](https://discord.com/developers/docs/topics/rpc#setvoicesettings).
+    fn set_voice_settings(&mut self, args: VoiceSettings) -> Result<VoiceSettings> {
+        let args = json!(args);
+        let d = self.command("SET_VOICE_SETTINGS", args)?;
+        Ok(serde_json::from_value(d).map_err(|_| Error::JsonParseResponse)?)
     }
 
     /// Closes the Discord IPC connection. Implementation is dependent on platform.

--- a/src/discord_ipc.rs
+++ b/src/discord_ipc.rs
@@ -64,7 +64,7 @@ pub trait DiscordIpc {
     }
 
     #[doc(hidden)]
-    fn get_client_id(&self) -> &String;
+    fn get_client_id(&self) -> &str;
 
     #[doc(hidden)]
     fn connect_ipc(&mut self) -> Result<()>;
@@ -142,14 +142,14 @@ pub trait DiscordIpc {
         let mut header = [0; 8];
 
         self.read(&mut header)?;
-        let (op, length) = unpack(header.to_vec())?;
+        let (op, length) = unpack(&header)?;
 
         let mut data = vec![0u8; length as usize];
         self.read(&mut data)?;
 
-        let response = String::from_utf8(data.to_vec()).map_err(|_| Error::RecvUtf8Response)?;
+        let response = str::from_utf8(&data).map_err(|_| Error::RecvUtf8Response)?;
         let json_data =
-            serde_json::from_str::<Value>(&response).map_err(|_| Error::JsonParseResponse)?;
+            serde_json::from_str::<Value>(response).map_err(|_| Error::JsonParseResponse)?;
 
         Ok((op, json_data))
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,6 @@
 //! Error types for this crate.
+use core::fmt;
+
 use thiserror::Error;
 
 // TODO: add these error codes for the command method https://discord.com/developers/docs/topics/opcodes-and-status-codes#rpc
@@ -37,14 +39,128 @@ pub enum Error {
     #[error("failed to flush IPC socket")]
     FlushError(std::io::Error),
 
-    /// Failed to find data in response.
-    #[error("failed to find data in response")]
-    NoData,
+    /// Nonce command mismatch.
+    #[error("nonce command mismatch")]
+    NonceCommandMismatch,
+    /// IPC Command Error.
+    #[error("ipc command error ({0}): {1}")]
+    CommandError(RPCErrorCode, String),
 
+    // /// Failed to find data in response.
+    // #[error("failed to find data in response")]
+    // NoData,
     /// Failed to find authorization code in response.
     #[error("failed to find authorization code in response")]
     NoAuthorizationCode,
     /// Authentication failed.
     #[error("authentication failed")]
     AuthenticationFailed,
+}
+
+/// RPC Error Code
+#[derive(Debug, Clone, Copy)]
+#[repr(usize)]
+pub enum RPCErrorCode {
+    /// An undocumented error occurred.
+    UndocumentedError = 0,
+    /// An unknown error occurred.
+    UnknownError = 1000,
+    /// You sent an invalid payload.
+    InvalidPayload = 4000,
+    /// Invalid command name specified.
+    InvalidCommand = 4002,
+    /// Invalid guild ID specified.
+    InvalidGuild = 4003,
+    /// Invalid event name specified.
+    InvalidEvent = 4004,
+    /// Invalid channel ID specified.
+    InvalidChannel = 4005,
+    /// You lack permissions to access the given resource.
+    InvalidPermissions = 4006,
+    /// An invalid OAuth2 application ID was used to authorize or authenticate with.
+    InvalidClientId = 4007,
+    /// An invalid OAuth2 application origin was used to authorize or authenticate with.
+    InvalidOrigin = 4008,
+    /// An invalid OAuth2 token was used to authorize or authenticate with.
+    InvalidToken = 4009,
+    /// The specified user ID was invalid.
+    InvalidUser = 4010,
+    /// A standard OAuth2 error occurred; check the data object for the OAuth2 error details.
+    OAuth2Error = 5000,
+    /// An asynchronous `SELECT_TEXT_CHANNEL`/`SELECT_VOICE_CHANNEL` command timed out.
+    SelectChannelTimedOut = 5001,
+    /// An asynchronous `GET_GUILD` command timed out.
+    GetGuildTimedOut = 5002,
+    /// You tried to join a user to a voice channel but the user was already in one.
+    SelectVoiceForceRequired = 5003,
+    /// You tried to capture more than one shortcut key at once.
+    CaptureShortcutAlreadyListening = 5004,
+}
+impl From<usize> for RPCErrorCode {
+    fn from(x: usize) -> Self {
+        match x {
+            x if x == Self::UnknownError as usize => Self::UnknownError,
+            x if x == Self::InvalidPayload as usize => Self::InvalidPayload,
+            x if x == Self::InvalidCommand as usize => Self::InvalidCommand,
+            x if x == Self::InvalidGuild as usize => Self::InvalidGuild,
+            x if x == Self::InvalidEvent as usize => Self::InvalidEvent,
+            x if x == Self::InvalidChannel as usize => Self::InvalidChannel,
+            x if x == Self::InvalidPermissions as usize => Self::InvalidPermissions,
+            x if x == Self::InvalidClientId as usize => Self::InvalidClientId,
+            x if x == Self::InvalidOrigin as usize => Self::InvalidOrigin,
+            x if x == Self::InvalidToken as usize => Self::InvalidToken,
+            x if x == Self::InvalidUser as usize => Self::InvalidUser,
+            x if x == Self::OAuth2Error as usize => Self::OAuth2Error,
+            x if x == Self::SelectChannelTimedOut as usize => Self::SelectChannelTimedOut,
+            x if x == Self::GetGuildTimedOut as usize => Self::GetGuildTimedOut,
+            x if x == Self::SelectVoiceForceRequired as usize => Self::SelectVoiceForceRequired,
+            x if x == Self::CaptureShortcutAlreadyListening as usize => {
+                Self::CaptureShortcutAlreadyListening
+            }
+            _ => Self::UndocumentedError,
+        }
+    }
+}
+impl fmt::Display for RPCErrorCode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}({})", self, *self as usize)
+    }
+}
+
+/// RPC Close Event Code
+#[derive(Debug, Clone, Copy)]
+#[repr(usize)]
+pub enum RPCCloseEventCode {
+    /// An undocumented error occurred.
+    UndocumentedError = 0,
+    /// You connected to the RPC server with an invalid client ID.
+    InvalidClientId = 4000,
+    /// You connected to the RPC server with an invalid origin.
+    InvalidOrigin = 4001,
+    /// You are being rate limited.
+    RateLimited = 4002,
+    /// The OAuth2 token associated with a connection was revoked, get a new one!
+    TokenRevoked = 4003,
+    /// The RPC Server version specified in the connection string was not valid.
+    InvalidVersion = 4004,
+    /// The encoding specified in the connection string was not valid.
+    InvalidEncoding = 4005,
+}
+impl From<usize> for RPCCloseEventCode {
+    fn from(x: usize) -> Self {
+        match x {
+            x if x == Self::InvalidClientId as usize => Self::InvalidClientId,
+            x if x == Self::InvalidOrigin as usize => Self::InvalidOrigin,
+            x if x == Self::RateLimited as usize => Self::RateLimited,
+            x if x == Self::TokenRevoked as usize => Self::TokenRevoked,
+            x if x == Self::InvalidVersion as usize => Self::InvalidVersion,
+            x if x == Self::InvalidEncoding as usize => Self::InvalidEncoding,
+            _ => Self::UndocumentedError,
+        }
+    }
+}
+impl fmt::Display for RPCCloseEventCode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}({})", self, *self as usize)
+    }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,8 @@
 //! Error types for this crate.
 use thiserror::Error;
 
+// TODO: add these error codes for the command method https://discord.com/developers/docs/topics/opcodes-and-status-codes#rpc
+
 /// Error type for this crate.
 #[derive(Error, Debug)]
 pub enum Error {

--- a/src/error.rs
+++ b/src/error.rs
@@ -34,4 +34,15 @@ pub enum Error {
     /// Failed to flush IPC socket.
     #[error("failed to flush IPC socket")]
     FlushError(std::io::Error),
+
+    /// Failed to find data in response.
+    #[error("failed to find data in response")]
+    NoData,
+
+    /// Failed to find authorization code in response.
+    #[error("failed to find authorization code in response")]
+    NoAuthorizationCode,
+    /// Authentication failed.
+    #[error("authentication failed")]
+    AuthenticationFailed,
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -22,6 +22,9 @@ pub enum Error {
     #[error("failed to parse response json")]
     JsonParseResponse,
 
+    /// Failed to find IPC socket.
+    #[error("failed to find IPC socket")]
+    IPCNotFound,
     /// Failed to connect to IPC socket.
     #[error("failed to connect to IPC socket")]
     IPCConnectionFailed,

--- a/src/ipc_unix.rs
+++ b/src/ipc_unix.rs
@@ -11,9 +11,12 @@ use std::{
 // Environment keys to search for the Discord pipe
 const ENV_KEYS: [&str; 4] = ["XDG_RUNTIME_DIR", "TMPDIR", "TMP", "TEMP"];
 
-const APP_SUBPATHS: [&str; 4] = [
+const APP_SUBPATHS: [&str; 7] = [
     "",
     "app/com.discordapp.Discord/",
+    "app/dev.vencord.Vesktop/",
+    ".flatpak/com.discordapp.Discord/xdg-run/",
+    ".flatpak/dev.vencord.Vesktop/xdg-run/",
     "snap.discord-canary/",
     "snap.discord/",
 ];
@@ -37,61 +40,63 @@ impl DiscordIpcClient {
     /// ```
     /// let ipc_client = DiscordIpcClient::new("<some client id>");
     /// ```
-    pub fn new(client_id: &str) -> Self {
+    pub fn new<T: AsRef<str>>(client_id: T) -> Self {
         Self {
-            client_id: client_id.to_string(),
+            client_id: client_id.as_ref().to_string(),
             socket: None,
         }
     }
 
-    fn get_pipe_pattern() -> PathBuf {
-        log::debug!("get_pipe_pattern: {}", var("SNAP").is_ok());
-        let mut path = String::new();
+    fn find_pipe() -> Option<PathBuf> {
+        let snap_flag = var("SNAP").is_ok();
+        log::debug!("find_pipe: snap_flag is {}", snap_flag);
 
         for key in &ENV_KEYS {
-            match var(key) {
+            let base_path = match var(key) {
                 Ok(val) => {
-                    if var("SNAP").is_ok() {
-                        if key == &ENV_KEYS[0] {
-                            path = val
-                                .rsplit_once('/')
-                                .map(|(parent, _)| parent)
-                                .unwrap_or("")
-                                .to_string();
-                        }
+                    if snap_flag && key == &ENV_KEYS[0] {
+                        let path = val.rsplit_once('/').map_or("", |(parent, _)| parent);
+                        PathBuf::from(path)
                     } else {
-                        path = val;
+                        PathBuf::from(val)
                     }
-                    break;
+                },
+                Err(_) => continue,
+            };
+
+            if !base_path.is_dir() { continue }
+
+            for i in 0..10 {
+                let pipe_name = format!("discord-ipc-{}", i);
+
+                for subpath in APP_SUBPATHS {
+                    let pipe_path = base_path
+                        .join(subpath)
+                        .join(&pipe_name);
+
+                    if pipe_path.exists() {
+                        log::debug!("find_pipe: found pipe at {}", pipe_path.display());
+                        return Some(pipe_path)
+                    }
                 }
-                Err(_e) => continue,
             }
         }
-        PathBuf::from(path)
+
+        log::warn!("find_pipe: could not find pipe");
+        None
     }
 }
 
 impl DiscordIpc for DiscordIpcClient {
     fn connect_ipc(&mut self) -> Result<()> {
-        for i in 0..10 {
-            for subpath in APP_SUBPATHS {
-                let path = DiscordIpcClient::get_pipe_pattern()
-                    .join(subpath)
-                    .join(format!("discord-ipc-{}", i));
+        let pipe = Self::find_pipe().ok_or(Error::IPCNotFound)?;
 
-                log::debug!("connect_ipc: {}", path.display());
-
-                match UnixStream::connect(&path) {
-                    Ok(socket) => {
-                        self.socket = Some(socket);
-                        return Ok(());
-                    }
-                    Err(err) => {
-                        log::debug!("connect_ipc: {}", err);
-                        continue;
-                    }
-                }
+        match UnixStream::connect(&pipe) {
+            Ok(socket) => {
+                self.socket = Some(socket);
+                return Ok(());
             }
+            Err(err) => log::debug!("connect_ipc: {}", err),
         }
 
         Err(Error::IPCConnectionFailed)
@@ -115,7 +120,7 @@ impl DiscordIpc for DiscordIpcClient {
 
     fn close(&mut self) -> Result<()> {
         let data = json!({});
-        if self.send(data, 2).is_ok() {}
+        let _ = self.send(data, 2);
 
         let socket = self.socket.as_mut().ok_or(Error::NotConnected)?;
 
@@ -123,12 +128,60 @@ impl DiscordIpc for DiscordIpcClient {
         match socket.shutdown(Shutdown::Both) {
             Ok(()) => (),
             Err(_err) => (),
-        };
+        }
 
         Ok(())
     }
 
-    fn get_client_id(&self) -> &String {
+    fn get_client_id(&self) -> &str {
         &self.client_id
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::env::{remove_var, set_var};
+    use std::fs;
+
+    use super::*;
+
+    #[test]
+    fn find_pipe() {
+        remove_var("SNAP");
+        set_var("XDG_RUNTIME_DIR", "/this/path/should/not/exist");
+        set_var("TMPDIR", "/tmp");
+        fs::write("/tmp/discord-ipc-4", "hi").expect("Could not create dummy pipe");
+
+        assert_eq! {
+            DiscordIpcClient::find_pipe(),
+            Some(PathBuf::from("/tmp/discord-ipc-4"))
+        };
+
+        // FIXME: Snap needs better tests
+        set_var("SNAP", "/snap/discord");
+
+        assert_eq! {
+            DiscordIpcClient::find_pipe(),
+            Some(PathBuf::from("/tmp/discord-ipc-4"))
+        };
+
+        remove_var("XDG_RUNTIME_DIR");
+        remove_var("TMPDIR");
+        remove_var("TEMP");
+        remove_var("TMP");
+
+        assert_eq! {
+            DiscordIpcClient::find_pipe(),
+            None
+        };
+
+        set_var("XDG_RUNTIME_DIR", "/this/path/should/not/exist");
+
+        assert_eq! {
+            DiscordIpcClient::find_pipe(),
+            None
+        };
+
+        fs::remove_file("/tmp/discord-ipc-4").expect("Could not remove dummy pipe");
     }
 }

--- a/src/ipc_windows.rs
+++ b/src/ipc_windows.rs
@@ -26,9 +26,9 @@ impl DiscordIpcClient {
     /// ```
     /// let ipc_client = DiscordIpcClient::new("<some client id>");
     /// ```
-    pub fn new(client_id: &str) -> Self {
+    pub fn new<T: AsRef<str>>(client_id: T) -> Self {
         Self {
-            client_id: client_id.to_string(),
+            client_id: client_id.as_ref().to_string(),
             socket: None,
         }
     }
@@ -71,14 +71,15 @@ impl DiscordIpc for DiscordIpcClient {
         let data = json!({});
         if self.send(data, 2).is_ok() {}
 
-        let socket = self.socket.as_mut().ok_or(Error::NotConnected)?;
+        let mut socket = self.socket.take().ok_or(Error::NotConnected)?;
 
         socket.flush().map_err(Error::FlushError)?;
+        drop(socket);
 
         Ok(())
     }
 
-    fn get_client_id(&self) -> &String {
+    fn get_client_id(&self) -> &str {
         &self.client_id
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 //! use discord_rich_presence::{activity, DiscordIpc, DiscordIpcClient};
 //!
 //! fn main() -> Result<(), Box<dyn std::error::Error>> {
-//!     let mut client = DiscordIpcClient::new("<some client id>")?;
+//!     let mut client = DiscordIpcClient::new("<some client id>");
 //!     client.connect()?;
 //!
 //!     let payload = activity::Activity::new().state("Hello world!");
@@ -22,7 +22,11 @@
 mod discord_ipc;
 mod pack_unpack;
 pub use discord_ipc::*;
-pub mod activity;
+mod types {
+    pub mod activity;
+    pub mod voice_settings;
+}
+pub use types::*;
 pub mod error;
 
 #[cfg(unix)]

--- a/src/pack_unpack.rs
+++ b/src/pack_unpack.rs
@@ -13,8 +13,7 @@ pub fn pack(opcode: u32, data_len: u32) -> Vec<u8> {
     bytes
 }
 
-pub fn unpack(data: Vec<u8>) -> Result<(u32, u32), Error> {
-    let data = data.as_slice();
+pub fn unpack(data: &[u8]) -> Result<(u32, u32), Error> {
     let (opcode, header) = data.split_at(std::mem::size_of::<u32>());
 
     let opcode = u32::from_le_bytes(opcode.try_into().map_err(|_| Error::DecodeOpcode)?);

--- a/src/types/activity.rs
+++ b/src/types/activity.rs
@@ -1,104 +1,60 @@
 //! Provides an interface for building activities to send
 //! to Discord via [`DiscordIpc::set_activity`](crate::DiscordIpc::set_activity).
+
 use serde_derive::Serialize;
 use serde_repr::Serialize_repr;
 
 /// A struct representing a Discord rich presence activity
-///
-/// Note that all methods return `Self`, and can be chained
-/// for fluency
+#[serde_with::skip_serializing_none]
 #[derive(Serialize, Clone)]
 pub struct Activity<'a> {
-    #[serde(skip_serializing_if = "Option::is_none")]
     state: Option<&'a str>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     details: Option<&'a str>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     timestamps: Option<Timestamps>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     party: Option<Party<'a>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     assets: Option<Assets<'a>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     secrets: Option<Secrets<'a>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     buttons: Option<Vec<Button<'a>>>,
-
-    #[serde(skip_serializing_if = "Option::is_none", rename = "type")]
+    #[serde(rename = "type")]
     activity_type: Option<ActivityType>,
 }
 
 /// A struct representing an `Activity`'s timestamps
-///
-/// Note that all methods return `Self`, and can be chained
-/// for fluency
+#[serde_with::skip_serializing_none]
 #[derive(Serialize, Clone)]
 pub struct Timestamps {
-    #[serde(skip_serializing_if = "Option::is_none")]
     start: Option<i64>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     end: Option<i64>,
 }
 
 /// A struct representing an `Activity`'s game party
-///
-/// Note that all methods return `Self`, and can be chained
-/// for fluency
+#[serde_with::skip_serializing_none]
 #[derive(Serialize, Clone)]
 pub struct Party<'a> {
-    #[serde(skip_serializing_if = "Option::is_none")]
     id: Option<&'a str>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     size: Option<[i32; 2]>,
 }
 
-/// A struct representing the art assets and hover text
-/// used by an `Activity`
-///
-/// Note that all methods return `Self`, and can be chained
-/// for fluency
+/// A struct representing the art assets and hover text used by an `Activity`
+#[serde_with::skip_serializing_none]
 #[derive(Serialize, Clone)]
 pub struct Assets<'a> {
-    #[serde(skip_serializing_if = "Option::is_none")]
     large_image: Option<&'a str>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     large_text: Option<&'a str>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     small_image: Option<&'a str>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     small_text: Option<&'a str>,
 }
 
-/// A struct representing the secrets used by an
-/// `Activity`
-///
-/// Note that all methods return `Self`, and can be chained
-/// for fluency
+/// A struct representing the secrets used by an `Activity`
+#[serde_with::skip_serializing_none]
 #[derive(Serialize, Clone)]
 pub struct Secrets<'a> {
-    #[serde(skip_serializing_if = "Option::is_none")]
     join: Option<&'a str>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     spectate: Option<&'a str>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     r#match: Option<&'a str>,
 }
 
-/// A struct representing the buttons that are
-/// attached to an `Activity`
+/// A struct representing the buttons that are attached to an `Activity`
 ///
 /// An activity may have a maximum of 2 buttons
 #[derive(Serialize, Clone)]
@@ -107,7 +63,7 @@ pub struct Button<'a> {
     url: &'a str,
 }
 
-/// A struct to set the Activity Type of the `Activity`
+/// An enum representing the Activity Type of the `Activity`
 #[derive(Serialize_repr, Clone)]
 #[repr(u8)]
 pub enum ActivityType {

--- a/src/types/activity.rs
+++ b/src/types/activity.rs
@@ -3,13 +3,28 @@
 
 use serde_derive::Serialize;
 use serde_repr::Serialize_repr;
+use std::borrow::Cow;
 
 /// A struct representing a Discord rich presence activity
 #[serde_with::skip_serializing_none]
 #[derive(Serialize, Clone)]
 pub struct Activity<'a> {
-    state: Option<&'a str>,
-    details: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    name: Option<Cow<'a, str>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    state: Option<Cow<'a, str>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    state_url: Option<Cow<'a, str>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    details: Option<Cow<'a, str>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    details_url: Option<Cow<'a, str>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     timestamps: Option<Timestamps>,
     party: Option<Party<'a>>,
     assets: Option<Assets<'a>>,
@@ -17,13 +32,27 @@ pub struct Activity<'a> {
     buttons: Option<Vec<Button<'a>>>,
     #[serde(rename = "type")]
     activity_type: Option<ActivityType>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    status_display_type: Option<StatusDisplayType>,
 }
 
 /// A struct representing an `Activity`'s timestamps
-#[serde_with::skip_serializing_none]
+///
+/// For `ActivityType::Listening` and `ActivityType::Watching`,
+/// including both `start` and `end` timestamps will display
+/// a time bar
+///
+/// Note that all methods return `Self`, and can be chained
+/// for fluency
 #[derive(Serialize, Clone)]
 pub struct Timestamps {
+    /// Unix time (in milliseconds) of when the activity started
+    #[serde(skip_serializing_if = "Option::is_none")]
     start: Option<i64>,
+
+    /// Unix time (in milliseconds) of when the activity ends
+    #[serde(skip_serializing_if = "Option::is_none")]
     end: Option<i64>,
 }
 
@@ -31,7 +60,10 @@ pub struct Timestamps {
 #[serde_with::skip_serializing_none]
 #[derive(Serialize, Clone)]
 pub struct Party<'a> {
-    id: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    id: Option<Cow<'a, str>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     size: Option<[i32; 2]>,
 }
 
@@ -39,19 +71,37 @@ pub struct Party<'a> {
 #[serde_with::skip_serializing_none]
 #[derive(Serialize, Clone)]
 pub struct Assets<'a> {
-    large_image: Option<&'a str>,
-    large_text: Option<&'a str>,
-    small_image: Option<&'a str>,
-    small_text: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    large_image: Option<Cow<'a, str>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    large_text: Option<Cow<'a, str>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    large_url: Option<Cow<'a, str>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    small_image: Option<Cow<'a, str>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    small_text: Option<Cow<'a, str>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    small_url: Option<Cow<'a, str>>,
 }
 
 /// A struct representing the secrets used by an `Activity`
 #[serde_with::skip_serializing_none]
 #[derive(Serialize, Clone)]
 pub struct Secrets<'a> {
-    join: Option<&'a str>,
-    spectate: Option<&'a str>,
-    r#match: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    join: Option<Cow<'a, str>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    spectate: Option<Cow<'a, str>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    r#match: Option<Cow<'a, str>>,
 }
 
 /// A struct representing the buttons that are attached to an `Activity`
@@ -59,8 +109,8 @@ pub struct Secrets<'a> {
 /// An activity may have a maximum of 2 buttons
 #[derive(Serialize, Clone)]
 pub struct Button<'a> {
-    label: &'a str,
-    url: &'a str,
+    label: Cow<'a, str>,
+    url: Cow<'a, str>,
 }
 
 /// An enum representing the Activity Type of the `Activity`
@@ -73,56 +123,103 @@ pub enum ActivityType {
     Listening = 2,
     /// Activity type "Watching X"
     Watching = 3,
+    /// Activity type, "<custom status message>". Supported in some inofficial discord clients
+    Custom = 4,
     /// Activity type "Competing in X"
     Competing = 5,
 }
 
+/// A struct to set the Status Display Type of the `Activity`
+/// Controls which field is displayed in the user's status text in the member list
+#[derive(Serialize_repr, Clone)]
+#[repr(u8)]
+pub enum StatusDisplayType {
+    /// "Listening to Spotify"
+    Name = 0,
+    /// "Listening to Rick Astley"
+    State = 1,
+    /// "Listening to Never Gonna Give You Up"
+    Details = 2,
+}
+
 impl<'a> Activity<'a> {
     /// Creates a new `Activity`
-    pub fn new() -> Self {
+    #[must_use]
+    pub const fn new() -> Self {
         Activity {
+            name: None,
             state: None,
+            state_url: None,
             details: None,
+            details_url: None,
             assets: None,
             buttons: None,
             party: None,
             secrets: None,
             timestamps: None,
             activity_type: None,
+            status_display_type: None,
         }
     }
 
+    /// Sets the name of the activity (overrides default App name)
+    #[must_use]
+    pub fn name<S: Into<Cow<'a, str>>>(mut self, name: S) -> Self {
+        self.name = Some(name.into());
+        self
+    }
+
     /// Sets the state of the activity
-    pub fn state(mut self, state: &'a str) -> Self {
-        self.state = Some(state);
+    #[must_use]
+    pub fn state<S: Into<Cow<'a, str>>>(mut self, state: S) -> Self {
+        self.state = Some(state.into());
+        self
+    }
+
+    /// Sets the state URL of the activity
+    #[must_use]
+    pub fn state_url<S: Into<Cow<'a, str>>>(mut self, state_url: S) -> Self {
+        self.state_url = Some(state_url.into());
         self
     }
 
     /// Sets the details of the activity
-    pub fn details(mut self, details: &'a str) -> Self {
-        self.details = Some(details);
+    #[must_use]
+    pub fn details<S: Into<Cow<'a, str>>>(mut self, details: S) -> Self {
+        self.details = Some(details.into());
+        self
+    }
+
+    /// Sets the details URL of the activity
+    #[must_use]
+    pub fn details_url<S: Into<Cow<'a, str>>>(mut self, details_url: S) -> Self {
+        self.details_url = Some(details_url.into());
         self
     }
 
     /// Add a `Timestamps` to this activity
-    pub fn timestamps(mut self, timestamps: Timestamps) -> Self {
+    #[must_use]
+    pub const fn timestamps(mut self, timestamps: Timestamps) -> Self {
         self.timestamps = Some(timestamps);
         self
     }
 
     /// Add a `Party` to this activity
+    #[must_use]
     pub fn party(mut self, party: Party<'a>) -> Self {
         self.party = Some(party);
         self
     }
 
     /// Add an `Assets` to this activity
+    #[must_use]
     pub fn assets(mut self, assets: Assets<'a>) -> Self {
         self.assets = Some(assets);
         self
     }
 
     /// Add a `Secrets` to this activity
+    #[must_use]
     pub fn secrets(mut self, secrets: Secrets<'a>) -> Self {
         self.secrets = Some(secrets);
         self
@@ -131,6 +228,7 @@ impl<'a> Activity<'a> {
     /// Add a `Vec` of `Button`s to this activity
     ///
     /// An activity may contain no more than 2 buttons
+    #[must_use]
     pub fn buttons(mut self, buttons: Vec<Button<'a>>) -> Self {
         // API call fails if the array is empty, so we skip serialization
         // entirely if this is the case
@@ -143,13 +241,21 @@ impl<'a> Activity<'a> {
     }
 
     /// Add an `ActivityType` to this activity
-    pub fn activity_type(mut self, activity_type: ActivityType) -> Self {
+    #[must_use]
+    pub const fn activity_type(mut self, activity_type: ActivityType) -> Self {
         self.activity_type = Some(activity_type);
+        self
+    }
+
+    /// Add a `StatusDisplayType` to this activity
+    #[must_use]
+    pub const fn status_display_type(mut self, status_display_type: StatusDisplayType) -> Self {
+        self.status_display_type = Some(status_display_type);
         self
     }
 }
 
-impl<'a> Default for Activity<'a> {
+impl Default for Activity<'_> {
     fn default() -> Self {
         Self::new()
     }
@@ -157,21 +263,24 @@ impl<'a> Default for Activity<'a> {
 
 impl Timestamps {
     /// Creates a new `Timestamps`
-    pub fn new() -> Self {
-        Timestamps {
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
             start: None,
             end: None,
         }
     }
 
     /// Sets the start time
-    pub fn start(mut self, start: i64) -> Self {
+    #[must_use]
+    pub const fn start(mut self, start: i64) -> Self {
         self.start = Some(start);
         self
     }
 
     /// Sets the end time
-    pub fn end(mut self, end: i64) -> Self {
+    #[must_use]
+    pub const fn end(mut self, end: i64) -> Self {
         self.end = Some(end);
         self
     }
@@ -185,16 +294,18 @@ impl Default for Timestamps {
 
 impl<'a> Party<'a> {
     /// Creates a new `Party`
-    pub fn new() -> Self {
-        Party {
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
             id: None,
             size: None,
         }
     }
 
     /// Sets the ID of the party
-    pub fn id(mut self, id: &'a str) -> Self {
-        self.id = Some(id);
+    #[must_use]
+    pub fn id<S: Into<Cow<'a, str>>>(mut self, id: S) -> Self {
+        self.id = Some(id.into());
         self
     }
 
@@ -206,13 +317,14 @@ impl<'a> Party<'a> {
     /// // of 1, and a max size of 3
     /// let party = Party::new().size([1, 3])
     /// ```
-    pub fn size(mut self, size: [i32; 2]) -> Self {
+    #[must_use]
+    pub const fn size(mut self, size: [i32; 2]) -> Self {
         self.size = Some(size);
         self
     }
 }
 
-impl<'a> Default for Party<'a> {
+impl Default for Party<'_> {
     fn default() -> Self {
         Self::new()
     }
@@ -220,51 +332,64 @@ impl<'a> Default for Party<'a> {
 
 impl<'a> Assets<'a> {
     /// Creates a new `Assets`
-    pub fn new() -> Self {
-        Assets {
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
             large_image: None,
             large_text: None,
+            large_url: None,
             small_image: None,
             small_text: None,
+            small_url: None,
         }
     }
 
-    /// Sets the name of the art asset to be used as the large
-    /// image
-    ///
-    /// Alternatively, the URL of the resource to be used as
-    /// the large image
-    pub fn large_image(mut self, large_image: &'a str) -> Self {
-        self.large_image = Some(large_image);
+    /// Sets the asset name or URL to be used as the large image
+    #[must_use]
+    pub fn large_image<S: Into<Cow<'a, str>>>(mut self, large_image: S) -> Self {
+        self.large_image = Some(large_image.into());
         self
     }
 
     /// Sets the text to be shown when hovering over the large
     /// image
-    pub fn large_text(mut self, large_text: &'a str) -> Self {
-        self.large_text = Some(large_text);
+    #[must_use]
+    pub fn large_text<S: Into<Cow<'a, str>>>(mut self, large_text: S) -> Self {
+        self.large_text = Some(large_text.into());
         self
     }
 
-    /// Sets the name of the art asset to be used as the small
-    /// image
-    ///
-    /// Alternatively, the URL of the resource to be used as
-    /// the small image
-    pub fn small_image(mut self, small_image: &'a str) -> Self {
-        self.small_image = Some(small_image);
+    /// Sets the url to be shown when clicking the large image
+    #[must_use]
+    pub fn large_url<S: Into<Cow<'a, str>>>(mut self, large_url: S) -> Self {
+        self.large_url = Some(large_url.into());
+        self
+    }
+
+    /// Sets the asset name or URL to be used as the small image
+    #[must_use]
+    pub fn small_image<S: Into<Cow<'a, str>>>(mut self, small_image: S) -> Self {
+        self.small_image = Some(small_image.into());
         self
     }
 
     /// Sets the text that is shown when hovering over the small
     /// image
-    pub fn small_text(mut self, small_text: &'a str) -> Self {
-        self.small_text = Some(small_text);
+    #[must_use]
+    pub fn small_text<S: Into<Cow<'a, str>>>(mut self, small_text: S) -> Self {
+        self.small_text = Some(small_text.into());
+        self
+    }
+
+    /// Sets the url to be shown when clicking the small image
+    #[must_use]
+    pub fn small_url<S: Into<Cow<'a, str>>>(mut self, small_url: S) -> Self {
+        self.small_url = Some(small_url.into());
         self
     }
 }
 
-impl<'a> Default for Assets<'a> {
+impl Default for Assets<'_> {
     fn default() -> Self {
         Self::new()
     }
@@ -272,8 +397,9 @@ impl<'a> Default for Assets<'a> {
 
 impl<'a> Secrets<'a> {
     /// Creates a new `Secrets`
-    pub fn new() -> Self {
-        Secrets {
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
             join: None,
             spectate: None,
             r#match: None,
@@ -281,25 +407,28 @@ impl<'a> Secrets<'a> {
     }
 
     /// Sets the secret for joining a game party
-    pub fn join(mut self, join: &'a str) -> Self {
-        self.join = Some(join);
+    #[must_use]
+    pub fn join<S: Into<Cow<'a, str>>>(mut self, join: S) -> Self {
+        self.join = Some(join.into());
         self
     }
 
     /// Sets the secret for spectating a match
-    pub fn spectate(mut self, spectate: &'a str) -> Self {
-        self.spectate = Some(spectate);
+    #[must_use]
+    pub fn spectate<S: Into<Cow<'a, str>>>(mut self, spectate: S) -> Self {
+        self.spectate = Some(spectate.into());
         self
     }
 
     /// Sets the secret for a specific, instanced match
-    pub fn r#match(mut self, r#match: &'a str) -> Self {
-        self.r#match = Some(r#match);
+    #[must_use]
+    pub fn r#match<S: Into<Cow<'a, str>>>(mut self, r#match: S) -> Self {
+        self.r#match = Some(r#match.into());
         self
     }
 }
 
-impl<'a> Default for Secrets<'a> {
+impl Default for Secrets<'_> {
     fn default() -> Self {
         Self::new()
     }
@@ -312,7 +441,10 @@ impl<'a> Button<'a> {
     /// The label must be 1-32 characters long
     ///
     /// The URL must be 1-512 characters long
-    pub fn new(label: &'a str, url: &'a str) -> Self {
-        Button { label, url }
+    pub fn new<L: Into<Cow<'a, str>>, U: Into<Cow<'a, str>>>(label: L, url: U) -> Self {
+        Self {
+            label: label.into(),
+            url: url.into(),
+        }
     }
 }

--- a/src/types/voice_settings.rs
+++ b/src/types/voice_settings.rs
@@ -116,8 +116,8 @@ impl VoiceInputSettings {
     }
 
     /// Sets the input device by its ID.
-    pub fn device_id(mut self, device_id: String) -> Self {
-        self.device_id = Some(device_id);
+    pub fn device_id(mut self, device_id: impl ToString) -> Self {
+        self.device_id = Some(device_id.to_string());
         self
     }
 
@@ -146,8 +146,8 @@ impl VoiceOutputSettings {
     }
 
     /// Sets the input device by its ID.
-    pub fn device_id(mut self, device_id: String) -> Self {
-        self.device_id = Some(device_id);
+    pub fn device_id(mut self, device_id: impl ToString) -> Self {
+        self.device_id = Some(device_id.to_string());
         self
     }
 
@@ -239,11 +239,11 @@ pub struct ShortcutKeyCombo {
 }
 impl ShortcutKeyCombo {
     /// Creates a new `ShortcutKeyCombo`.
-    pub fn new(key_type: ShortcutKeyType, code: usize, name: String) -> Self {
+    pub fn new(key_type: ShortcutKeyType, code: usize, name: impl ToString) -> Self {
         Self {
             key_type: key_type,
             code: code,
-            name: name,
+            name: name.to_string(),
         }
     }
 }

--- a/src/types/voice_settings.rs
+++ b/src/types/voice_settings.rs
@@ -1,0 +1,264 @@
+//! Interface for viewing and updating voice settings
+//! via [`DiscordIpc::get_voice_settings`](crate::DiscordIpc::get_voice_settings)
+//! and [`DiscordIpc::set_voice_settings`](crate::DiscordIpc::set_voice_settings).
+
+use serde_derive::{Deserialize, Serialize};
+
+/// Discord voice settings. See [Discord RPC docs](https://discord.com/developers/docs/topics/rpc#getvoicesettings-get-voice-settings-response-structure) for details.
+#[serde_with::skip_serializing_none]
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct VoiceSettings {
+    /// Voice Input Settings
+    pub input: Option<VoiceInputSettings>,
+    /// Voice Output Settings
+    pub output: Option<VoiceOutputSettings>,
+    /// Voice Mode Settings
+    pub mode: Option<VoiceModeSettings>,
+    /// State of automatic gain control
+    pub automatic_gain_control: Option<bool>,
+    /// State of echo cancellation
+    pub echo_cancellation: Option<bool>,
+    /// State of noise suppression
+    pub noise_suppression: Option<bool>,
+    /// State of "quality of service" setting
+    pub qos: Option<bool>,
+    /// State of silence warning
+    pub silence_warning: Option<bool>,
+    /// State of deafening
+    pub deaf: Option<bool>,
+    /// State of muting
+    pub mute: Option<bool>,
+}
+impl VoiceSettings {
+    /// Creates a new empty `VoiceSettings`.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets the Voice Input Settings.
+    pub fn input(mut self, input: VoiceInputSettings) -> Self {
+        self.input = Some(input);
+        self
+    }
+
+    /// Sets the Voice Output Settings.
+    pub fn output(mut self, output: VoiceOutputSettings) -> Self {
+        self.output = Some(output);
+        self
+    }
+
+    /// Sets the Voice Mode Settings.
+    pub fn mode(mut self, mode: VoiceModeSettings) -> Self {
+        self.mode = Some(mode);
+        self
+    }
+
+    /// Sets the state of automatic gain control.
+    pub fn automatic_gain_control(mut self, automatic_gain_control: bool) -> Self {
+        self.automatic_gain_control = Some(automatic_gain_control);
+        self
+    }
+
+    /// Sets the state of echo cancellation.
+    pub fn echo_cancellation(mut self, echo_cancellation: bool) -> Self {
+        self.echo_cancellation = Some(echo_cancellation);
+        self
+    }
+
+    /// Sets the state of noise suppression.
+    pub fn noise_suppression(mut self, noise_suppression: bool) -> Self {
+        self.noise_suppression = Some(noise_suppression);
+        self
+    }
+
+    /// Sets the state of "quality of service" setting.
+    pub fn qos(mut self, qos: bool) -> Self {
+        self.qos = Some(qos);
+        self
+    }
+
+    /// Sets the state of silence warning.
+    pub fn silence_warning(mut self, silence_warning: bool) -> Self {
+        self.silence_warning = Some(silence_warning);
+        self
+    }
+
+    /// Sets the state of deafening.
+    ///
+    /// Note that using deafening may require you to use both deaf and mute fields.
+    pub fn deaf(mut self, deaf: bool) -> Self {
+        self.deaf = Some(deaf);
+        self
+    }
+
+    /// Sets the state of muting.
+    pub fn mute(mut self, mute: bool) -> Self {
+        self.mute = Some(mute);
+        self
+    }
+}
+
+/// Voice input settings. See [Discord RPC docs](https://discord.com/developers/docs/topics/rpc#getvoicesettings-voice-settings-input-object) for details.
+#[serde_with::skip_serializing_none]
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct VoiceInputSettings {
+    /// Device ID of the current input device
+    pub device_id: Option<String>,
+    /// Input voice level percentage (min: 0, max: 100)
+    pub volume: Option<f32>,
+    /// List of available input devices
+    pub available_devices: Option<Vec<VoiceAvailableDevice>>,
+}
+impl VoiceInputSettings {
+    /// Creates a new empty `VoiceInputSettings`.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets the input device by its ID.
+    pub fn device_id(mut self, device_id: String) -> Self {
+        self.device_id = Some(device_id);
+        self
+    }
+
+    /// Sets the volume of the device.
+    pub fn volume(mut self, volume: f32) -> Self {
+        self.volume = Some(volume);
+        self
+    }
+}
+
+/// Voice output settings. See [Discord RPC docs](https://discord.com/developers/docs/topics/rpc#getvoicesettings-voice-settings-output-object) for details.
+#[serde_with::skip_serializing_none]
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct VoiceOutputSettings {
+    /// Device ID of the current output device
+    pub device_id: Option<String>,
+    /// Output voice level percentage (min: 0, max: 200)
+    pub volume: Option<f32>,
+    /// List of available output devices
+    pub available_devices: Option<Vec<VoiceAvailableDevice>>,
+}
+impl VoiceOutputSettings {
+    /// Creates a new empty `VoiceOutputSettings`.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets the input device by its ID.
+    pub fn device_id(mut self, device_id: String) -> Self {
+        self.device_id = Some(device_id);
+        self
+    }
+
+    /// Sets the volume of the device.
+    pub fn volume(mut self, volume: f32) -> Self {
+        self.volume = Some(volume);
+        self
+    }
+}
+
+/// An available audio device.
+#[serde_with::skip_serializing_none]
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct VoiceAvailableDevice {
+    /// ID of device for setting
+    pub id: String,
+    /// Name of device for displaying
+    pub name: String,
+}
+
+/// Voice mode settings. See [Discord RPC docs](https://discord.com/developers/docs/topics/rpc#getvoicesettings-voice-settings-mode-object) for details.
+#[serde_with::skip_serializing_none]
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct VoiceModeSettings {
+    #[serde(rename = "type")]
+    /// Voice Mode setting
+    pub voice_mode: Option<VoiceMode>,
+    /// whether the Voice Activity threshold is set automatically
+    pub auto_threshold: Option<bool>,
+    /// Voice Activity threshold (in dB) (min: -100, max: 0)
+    pub threshold: Option<f32>,
+    /// Shortcut Key Combo for activating this voice mode
+    pub shortcut: Option<Vec<ShortcutKeyCombo>>,
+    /// Push-to-Talk release delay (in ms) (min: 0, max: 2000)
+    pub delay: Option<f32>,
+}
+impl VoiceModeSettings {
+    /// Creates a new empty `VoiceModeSettings`.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets the state of voice mode.
+    pub fn voice_mode(mut self, voice_mode: VoiceMode) -> Self {
+        self.voice_mode = Some(voice_mode);
+        self
+    }
+
+    /// Sets the state of automatic voice activity threshold.
+    pub fn auto_threshold(mut self, auto_threshold: bool) -> Self {
+        self.auto_threshold = Some(auto_threshold);
+        self
+    }
+
+    /// Sets the voice activity threshold. Overridden by [`Self::auto_threshold`](Self::auto_threshold).
+    pub fn threshold(mut self, threshold: f32) -> Self {
+        self.threshold = Some(threshold);
+        self
+    }
+
+    /// Sets the push-to-talk release delay.
+    pub fn delay(mut self, delay: f32) -> Self {
+        self.delay = Some(delay);
+        self
+    }
+}
+
+/// Voice mode.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum VoiceMode {
+    /// Push to Talk
+    PushToTalk,
+    /// Voice Activity
+    VoiceActivity,
+}
+
+/// A shortcut key combo.
+#[serde_with::skip_serializing_none]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ShortcutKeyCombo {
+    #[serde(rename = "type")]
+    /// Key Type of shortcut combo
+    pub key_type: ShortcutKeyType,
+    /// Key scan code
+    pub code: usize,
+    /// Key name
+    pub name: String,
+}
+impl ShortcutKeyCombo {
+    /// Creates a new `ShortcutKeyCombo`.
+    pub fn new(key_type: ShortcutKeyType, code: usize, name: String) -> Self {
+        Self {
+            key_type: key_type,
+            code: code,
+            name: name,
+        }
+    }
+}
+
+/// Shortcut key type for a shortcut key combo.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+#[repr(u8)]
+pub enum ShortcutKeyType {
+    /// Keyboard Key
+    KeyboardKey = 0,
+    /// Mouse Button
+    MouseButton = 1,
+    /// Keyboard Modifier Key (Shift, Ctrl, Alt, Super)
+    KeyboardModifierKey = 2,
+    /// Gamepad Button
+    GamepadButton = 3,
+}

--- a/src/types/voice_settings.rs
+++ b/src/types/voice_settings.rs
@@ -105,7 +105,7 @@ pub struct VoiceInputSettings {
     /// Device ID of the current input device
     pub device_id: Option<String>,
     /// Input voice level percentage (min: 0, max: 100)
-    pub volume: Option<f32>,
+    pub volume: Option<f64>,
     /// List of available input devices
     pub available_devices: Option<Vec<VoiceAvailableDevice>>,
 }
@@ -122,7 +122,7 @@ impl VoiceInputSettings {
     }
 
     /// Sets the volume of the device.
-    pub fn volume(mut self, volume: f32) -> Self {
+    pub fn volume(mut self, volume: f64) -> Self {
         self.volume = Some(volume);
         self
     }
@@ -135,7 +135,7 @@ pub struct VoiceOutputSettings {
     /// Device ID of the current output device
     pub device_id: Option<String>,
     /// Output voice level percentage (min: 0, max: 200)
-    pub volume: Option<f32>,
+    pub volume: Option<f64>,
     /// List of available output devices
     pub available_devices: Option<Vec<VoiceAvailableDevice>>,
 }
@@ -152,7 +152,7 @@ impl VoiceOutputSettings {
     }
 
     /// Sets the volume of the device.
-    pub fn volume(mut self, volume: f32) -> Self {
+    pub fn volume(mut self, volume: f64) -> Self {
         self.volume = Some(volume);
         self
     }
@@ -178,11 +178,11 @@ pub struct VoiceModeSettings {
     /// whether the Voice Activity threshold is set automatically
     pub auto_threshold: Option<bool>,
     /// Voice Activity threshold (in dB) (min: -100, max: 0)
-    pub threshold: Option<f32>,
+    pub threshold: Option<f64>,
     /// Shortcut Key Combo for activating this voice mode
     pub shortcut: Option<Vec<ShortcutKeyCombo>>,
     /// Push-to-Talk release delay (in ms) (min: 0, max: 2000)
-    pub delay: Option<f32>,
+    pub delay: Option<f64>,
 }
 impl VoiceModeSettings {
     /// Creates a new empty `VoiceModeSettings`.
@@ -203,13 +203,13 @@ impl VoiceModeSettings {
     }
 
     /// Sets the voice activity threshold. Overridden by [`Self::auto_threshold`](Self::auto_threshold).
-    pub fn threshold(mut self, threshold: f32) -> Self {
+    pub fn threshold(mut self, threshold: f64) -> Self {
         self.threshold = Some(threshold);
         self
     }
 
     /// Sets the push-to-talk release delay.
-    pub fn delay(mut self, delay: f32) -> Self {
+    pub fn delay(mut self, delay: f64) -> Self {
         self.delay = Some(delay);
         self
     }
@@ -231,7 +231,8 @@ pub enum VoiceMode {
 pub struct ShortcutKeyCombo {
     #[serde(rename = "type")]
     /// Key Type of shortcut combo
-    pub key_type: ShortcutKeyType,
+    /// (KeyboardKey = 0, MouseButton=1, KeyboardModifierKey=2, GamepadButton=3)
+    pub key_type: usize,
     /// Key scan code
     pub code: usize,
     /// Key name
@@ -239,26 +240,11 @@ pub struct ShortcutKeyCombo {
 }
 impl ShortcutKeyCombo {
     /// Creates a new `ShortcutKeyCombo`.
-    pub fn new(key_type: ShortcutKeyType, code: usize, name: impl ToString) -> Self {
+    pub fn new(key_type: usize, code: usize, name: impl ToString) -> Self {
         Self {
             key_type: key_type,
             code: code,
             name: name.to_string(),
         }
     }
-}
-
-/// Shortcut key type for a shortcut key combo.
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
-#[repr(u8)]
-pub enum ShortcutKeyType {
-    /// Keyboard Key
-    KeyboardKey = 0,
-    /// Mouse Button
-    MouseButton = 1,
-    /// Keyboard Modifier Key (Shift, Ctrl, Alt, Super)
-    KeyboardModifierKey = 2,
-    /// Gamepad Button
-    GamepadButton = 3,
 }

--- a/tests/models_test.rs
+++ b/tests/models_test.rs
@@ -12,7 +12,11 @@ fn test_models() -> Result<(), Box<dyn Error>> {
         .assets(
             activity::Assets::new()
                 .large_image("large-image")
-                .large_text("Large text"),
+                .large_text("Large text")
+                .large_url("https://example.com")
+                .small_image("https://picsum.photos/id/128/200")
+                .small_text("Small image")
+                .small_url("https://picsum.photos/id/128/200")
         )
         .buttons(vec![activity::Button::new(
             "A button",


### PR DESCRIPTION
Adding more commands for expanded functionality. Anything beyond activity setting requires authorizing/authenticating with specific scopes.

I understand activity creation is undergoing a rewrite, these settings follow the older model but don't use anything lifetimes.

Tests were not written, but these do run on my Linux machine without issue.