### PR TITLE
fix: confirm pipe exists

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -18,6 +18,9 @@ pub enum Error {
     #[error("failed to parse response json")]
     JsonParseResponse,
 
+    /// Failed to find IPC socket.
+    #[error("failed to find IPC socket")]
+    IPCNotFound,
     /// Failed to connect to IPC socket.
     #[error("failed to connect to IPC socket")]
     IPCConnectionFailed,

--- a/src/ipc_unix.rs
+++ b/src/ipc_unix.rs
@@ -47,54 +47,56 @@ impl DiscordIpcClient {
         }
     }
 
-    fn get_pipe_pattern() -> PathBuf {
-        log::debug!("get_pipe_pattern: {}", var("SNAP").is_ok());
-        let mut path = String::new();
+    fn find_pipe() -> Option<PathBuf> {
+        let snap_flag = var("SNAP").is_ok();
+        log::debug!("find_pipe: snap_flag is {}", snap_flag);
 
         for key in &ENV_KEYS {
-            match var(key) {
+            let base_path = match var(key) {
                 Ok(val) => {
-                    if var("SNAP").is_ok() {
-                        if key == &ENV_KEYS[0] {
-                            path = val
-                                .rsplit_once('/')
-                                .map(|(parent, _)| parent)
-                                .unwrap_or("")
-                                .to_string();
-                        }
+                    if snap_flag && key == &ENV_KEYS[0] {
+                        let path = val.rsplit_once('/').map_or("", |(parent, _)| parent);
+                        PathBuf::from(path)
                     } else {
-                        path = val;
+                        PathBuf::from(val)
                     }
-                    break;
+                },
+                Err(_) => continue,
+            };
+
+            if !base_path.is_dir() { continue }
+
+            for i in 0..10 {
+                let pipe_name = format!("discord-ipc-{}", i);
+
+                for subpath in APP_SUBPATHS {
+                    let pipe_path = base_path
+                        .join(subpath)
+                        .join(&pipe_name);
+
+                    if pipe_path.exists() {
+                        log::debug!("find_pipe: found pipe at {}", pipe_path.display());
+                        return Some(pipe_path)
+                    }
                 }
-                Err(_e) => continue,
             }
         }
-        PathBuf::from(path)
+
+        log::warn!("find_pipe: could not find pipe");
+        None
     }
 }
 
 impl DiscordIpc for DiscordIpcClient {
     fn connect_ipc(&mut self) -> Result<()> {
-        for i in 0..10 {
-            for subpath in APP_SUBPATHS {
-                let path = DiscordIpcClient::get_pipe_pattern()
-                    .join(subpath)
-                    .join(format!("discord-ipc-{}", i));
+        let pipe = Self::find_pipe().ok_or(Error::IPCNotFound)?;
 
-                log::debug!("connect_ipc: {}", path.display());
-
-                match UnixStream::connect(&path) {
-                    Ok(socket) => {
-                        self.socket = Some(socket);
-                        return Ok(());
-                    }
-                    Err(err) => {
-                        log::debug!("connect_ipc: {}", err);
-                        continue;
-                    }
-                }
+        match UnixStream::connect(&pipe) {
+            Ok(socket) => {
+                self.socket = Some(socket);
+                return Ok(());
             }
+            Err(err) => log::debug!("connect_ipc: {}", err),
         }
 
         Err(Error::IPCConnectionFailed)
@@ -133,5 +135,53 @@ impl DiscordIpc for DiscordIpcClient {
 
     fn get_client_id(&self) -> &str {
         &self.client_id
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::env::{remove_var, set_var};
+    use std::fs;
+
+    use super::*;
+
+    #[test]
+    fn find_pipe() {
+        remove_var("SNAP");
+        set_var("XDG_RUNTIME_DIR", "/this/path/should/not/exist");
+        set_var("TMPDIR", "/tmp");
+        fs::write("/tmp/discord-ipc-4", "hi").expect("Could not create dummy pipe");
+
+        assert_eq! {
+            DiscordIpcClient::find_pipe(),
+            Some(PathBuf::from("/tmp/discord-ipc-4"))
+        };
+
+        // FIXME: Snap needs better tests
+        set_var("SNAP", "/snap/discord");
+
+        assert_eq! {
+            DiscordIpcClient::find_pipe(),
+            Some(PathBuf::from("/tmp/discord-ipc-4"))
+        };
+
+        remove_var("XDG_RUNTIME_DIR");
+        remove_var("TMPDIR");
+        remove_var("TEMP");
+        remove_var("TMP");
+
+        assert_eq! {
+            DiscordIpcClient::find_pipe(),
+            None
+        };
+
+        set_var("XDG_RUNTIME_DIR", "/this/path/should/not/exist");
+
+        assert_eq! {
+            DiscordIpcClient::find_pipe(),
+            None
+        };
+
+        fs::remove_file("/tmp/discord-ipc-4").expect("Could not remove dummy pipe");
     }
 }


### PR DESCRIPTION
This should resolve #56, but needs more testing.

I've added `Error::IPCNotFound` as not finding the IPC socket is a distinct error from failing to connect to it. This may result in an unused lint for the windows target.

I've replaced the `get_pipe_pattern()` method with `find_pipe()` to ease checking for pipe existance.

I've added a unit test for the new `find_pipe()` method, but there may be more cases to test against, and I may not be properly testing snap sandboxing.