### PR TITLE
example: clear activity

### DIFF
--- a/examples/presence.rs
+++ b/examples/presence.rs
@@ -13,6 +13,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         _ => (),
     }
 
-    client.close()?;
+    println!("Clearing activity...");
+    client.clear_activity()?;
+
+    println!("Activity cleared! Going to exit...");
+    match client.close() {
+        Ok(()) => (),
+        Err(err) => println!("Error closing IPC connection: {}", err),
+    }
+
     Ok(())
 }


### PR DESCRIPTION
Call clear explicitly so the activity is cleared after the example exits

Without this the activity will _NOT_ be cleared in discord once the example exits (on either Linux or Windows)

Tested on:
* Arch Linux (`7.0.5-arch1-1`)
* Windows 10 Pro N (`19045.5854`)

(Client close does not really clear the activity, see: https://github.com/vionya/discord-rich-presence/issues/37)